### PR TITLE
Add link to avr-rust organisation to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,10 @@ What is it that we really want? At a broad level:
 [@pftbest]: https://github.com/pftbest
 [@thejpster]: https://github.com/thejpster
 
+### Subprojects
+
+* [AVR fork of Rust](https://github.com/avr-rust/)
+
 ### Contact
 
 You can usually find the members of the embedded WG on the #rust-embedded channel (server:


### PR DESCRIPTION
As suggested by @japaric in #46.