### PR TITLE
[RFC] Bootstrap the tools team

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ The tools team maintains and develops core embedded tools.
 #### Members
 
 - [@japaric]
+- [@Emilgardis](https://github.com/Emilgardis)
 
 #### Projects
 

--- a/README.md
+++ b/README.md
@@ -47,8 +47,10 @@ The tools team maintains and develops core embedded tools.
 
 #### Members
 
-- [@japaric]
 - [@Emilgardis](https://github.com/Emilgardis)
+- [@japaric]
+- [@ryankurte](https://github.com/ryankurte)
+- [@therealprof](https://github.com/therealprof)
 
 #### Projects
 

--- a/README.md
+++ b/README.md
@@ -41,6 +41,23 @@ What is it that we really want? At a broad level:
 [@pftbest]: https://github.com/pftbest
 [@thejpster]: https://github.com/thejpster
 
+### The tools team
+
+The tools team maintains and develops core embedded tools.
+
+#### Members
+
+- [@japaric]
+
+#### Projects
+
+Projects maintained by the tools team
+
+- [`cargo-binutils`](https://github.com/japaric/cargo-binutils)
+- [`cross`](https://github.com/japaric/cross)
+- [`itm`](https://github.com/japaric/itm)
+- [`svd2rust`](https://github.com/japaric/svd2rust)
+
 ### Subprojects
 
 * [AVR fork of Rust](https://github.com/avr-rust/)


### PR DESCRIPTION
As per RFC #136 this PR kickstarts the tools team

Note that the team composition is not final. The team is expected to grow over time. The mechanism
for joining a team is specified in RFC #136.

@therealprof previously you expressed interest in cargo-binutils and having more debugging /
flashing tools. Would you be interested in joining this team to help maintain the existing tools and
develop new ones?

@Emilgardis @ryankurte currently you are collaborators of the svd2rust repository. Would you be
interested in joining this team to help maintain and develop the other tools we have?