### PR TITLE
[RFC] Bootstrap the HAL team

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ Board Support Crates and drivers.
 #### Members
 
 - [@japaric]
+- [@hannobraun]
 
 #### Projects
 

--- a/README.md
+++ b/README.md
@@ -41,6 +41,22 @@ What is it that we really want? At a broad level:
 [@pftbest]: https://github.com/pftbest
 [@thejpster]: https://github.com/thejpster
 
+### The HAL team
+
+The HAL team develops and maintains crates that ease the development of Hardware Abstraction Layers,
+Board Support Crates and drivers.
+
+#### Members
+
+- [@japaric]
+
+#### Projects
+
+Projects maintained by the HAL team.
+
+- [`embedded-hal`](https://github.com/japaric/embedded-hal)
+- [`linux-embedded-hal`](https://github.com/japaric/linux-embedded-hal)
+
 ### Subprojects
 
 * [AVR fork of Rust](https://github.com/avr-rust/)

--- a/README.md
+++ b/README.md
@@ -48,8 +48,9 @@ Board Support Crates and drivers.
 
 #### Members
 
-- [@japaric]
 - [@hannobraun]
+- [@japaric]
+- [@therealprof](https://github.com/therealprof)
 
 #### Projects
 


### PR DESCRIPTION
As per RFC #136 this PR kickstarts the HAL team

Note that the team composition is not final. The team is expected to grow over time. The mechanism
for joining a team is specified in RFC #136.

@dvc94ch @pftbest I think it would be great to have people from the MSP430 and RISCV teams
participate in this team to ensure the HAL will also work on MSP430 and RISCV microcontrollers.
Would you be interested in being part of this team?

@therealprof @hannobraun You are active collaborators of `embedded-hal`. Would you be interested in
being part of this team?

Currently there aren't too many crates assigned to the this team, but I can see a crate for
mocking the HAL to test drivers, and crates to make it easier to write I2C and SPI drivers (e.g.
dealing with registers) being added to it in the future.